### PR TITLE
Add routing and multi-page SSG

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,8 @@
       "version": "1.0.0",
       "dependencies": {
         "react": "^18.3.1",
-        "react-dom": "^18.3.1"
+        "react-dom": "^18.3.1",
+        "react-router-dom": "^6.30.1"
       },
       "devDependencies": {
         "@types/react": "^18.3.23",
@@ -434,6 +435,15 @@
         "@jridgewell/sourcemap-codec": "^1.4.10"
       }
     },
+    "node_modules/@remix-run/router": {
+      "version": "1.23.0",
+      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.23.0.tgz",
+      "integrity": "sha512-O3rHJzAQKamUz1fvE0Qaw0xSFqsA/yafi2iqeE0pvdFtCO1viYx8QL6f3Ln/aCCTLxs68SLf0KPM9eSeM8yBnA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/@tsconfig/node10": {
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.11.tgz",
@@ -644,6 +654,38 @@
       },
       "peerDependencies": {
         "react": "^18.3.1"
+      }
+    },
+    "node_modules/react-router": {
+      "version": "6.30.1",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.30.1.tgz",
+      "integrity": "sha512-X1m21aEmxGXqENEPG3T6u0Th7g0aS4ZmoNynhbs+Cn+q+QGTLt+d5IQ2bHAXKzKcxGJjxACpVbnYQSCRcfxHlQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@remix-run/router": "1.23.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8"
+      }
+    },
+    "node_modules/react-router-dom": {
+      "version": "6.30.1",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.30.1.tgz",
+      "integrity": "sha512-llKsgOkZdbPU1Eg3zK8lCn+sjD9wMRZZPuzmdWWX5SUs8OFkN5HnFVC0u5KMeMaC9aoancFI/KoLuKPqN+hxHw==",
+      "license": "MIT",
+      "dependencies": {
+        "@remix-run/router": "1.23.0",
+        "react-router": "6.30.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
       }
     },
     "node_modules/scheduler": {

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
   },
   "dependencies": {
     "react": "^18.3.1",
-    "react-dom": "^18.3.1"
+    "react-dom": "^18.3.1",
+    "react-router-dom": "^6.30.1"
   },
   "devDependencies": {
     "@types/react": "^18.3.23",

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -1,16 +1,11 @@
-import { useState } from "react"
+import React from "react";
+import { BrowserRouter } from "react-router-dom";
+import AppRoutes from "./routes";
 
-export type AppProps = {
-  initialCount: number
-}
-
-export default function App({ initialCount }: AppProps) {
-  const [count, setCount] = useState(initialCount)
+export default function App() {
   return (
-    <main style={{ padding: 24 }}>
-      <h1>Full-page Island</h1>
-      <p>Нажато: {count}</p>
-      <button onClick={() => setCount(c => c + 1)}>+1</button>
-    </main>
-  )
+    <BrowserRouter>
+      <AppRoutes />
+    </BrowserRouter>
+  );
 }

--- a/src/app/routes.tsx
+++ b/src/app/routes.tsx
@@ -1,0 +1,15 @@
+import React from "react";
+import { Routes, Route } from "react-router-dom";
+import HomePage from "../pages/index";
+import AboutPage from "../pages/about";
+import ContactPage from "../pages/contact";
+
+export default function AppRoutes() {
+  return (
+    <Routes>
+      <Route path="/" element={<HomePage />} />
+      <Route path="/about.html" element={<AboutPage />} />
+      <Route path="/contact.html" element={<ContactPage />} />
+    </Routes>
+  );
+}

--- a/src/build.tsx
+++ b/src/build.tsx
@@ -1,4 +1,4 @@
-import { writeFileSync, mkdirSync, existsSync, readdirSync } from "fs";
+import { writeFileSync, mkdirSync, rmSync, readdirSync } from "fs";
 import { resolve, join, basename, extname } from "path";
 import React from "react";
 import { renderToStaticMarkup } from "react-dom/server";
@@ -8,7 +8,8 @@ import AppRoutes from "./app/routes.js";
 async function build() {
   const projectRoot = process.cwd();
   const distDir = resolve(projectRoot, "dist");
-  if (!existsSync(distDir)) mkdirSync(distDir);
+  rmSync(distDir, { recursive: true, force: true });
+  mkdirSync(distDir, { recursive: true });
 
   const pagesDir = resolve(projectRoot, "src/pages");
   const pageFiles = readdirSync(pagesDir).filter(f => f.endsWith(".tsx"));

--- a/src/build.tsx
+++ b/src/build.tsx
@@ -1,60 +1,30 @@
-import { readFileSync, writeFileSync, mkdirSync, existsSync } from "fs";
-import { resolve, join } from "path";
+import { writeFileSync, mkdirSync, existsSync, readdirSync } from "fs";
+import { resolve, join, basename, extname } from "path";
 import React from "react";
 import { renderToStaticMarkup } from "react-dom/server";
-import { AppProps } from "./app/App.js"
+import { StaticRouter } from "react-router-dom/server";
+import AppRoutes from "./app/routes.js";
 
 async function build() {
   const projectRoot = process.cwd();
   const distDir = resolve(projectRoot, "dist");
   if (!existsSync(distDir)) mkdirSync(distDir);
 
-  // 1) Загружаем модуль страницы
-  const { default: App } = await import("./app/App.js");
-  // 2) Подтягиваем «getStaticProps» если есть
-  let pageProps: Record<string, unknown> = {};
-  try {
-    const mod = await import("./app/getStaticProps.js");
-    if (mod?.getStaticProps) {
-      const res = await mod.getStaticProps();
-      pageProps = (res?.props ?? {});
-    }
-  } catch (_) {
-    /* файла может не быть — это ок */
+  const pagesDir = resolve(projectRoot, "src/pages");
+  const pageFiles = readdirSync(pagesDir).filter(f => f.endsWith(".tsx"));
+
+  for (const file of pageFiles) {
+    const name = basename(file, extname(file));
+    const path = name === "index" ? "/" : `/${name}.html`;
+    const html = renderToStaticMarkup(
+      <StaticRouter location={path}>
+        <AppRoutes />
+      </StaticRouter>
+    );
+    const outFile = join(distDir, name === "index" ? "index.html" : `${name}.html`);
+    writeFileSync(outFile, "<!DOCTYPE html>" + html);
+    console.log(`✓ ${outFile} готов`);
   }
-
-  // 3) Рендерим в строку
-  const html = renderToStaticMarkup(
-    <html>
-      <head>
-        <meta charSet="utf-8" />
-        <title>Dynamic-but-SSG</title>
-        <link rel="stylesheet" href="/assets/styles.css" />
-      </head>
-      <body>
-        {/* корень React-дерева */}
-        <div id="__APP__">
-          <App {...pageProps as AppProps} />
-        </div>
-
-        {/* сериализованные данные для клиента */}
-        <script
-          id="__DATA__"
-          type="application/json"
-          // защита от XSS: минимально — JSON.stringify + replace <
-          dangerouslySetInnerHTML={{
-            __html: JSON.stringify(pageProps).replace(/</g, "\\u003c"),
-          }}
-        />
-
-        {/* клиентский бандл */}
-        <script src="/assets/client.js" type="module"></script>
-      </body>
-    </html>
-  );
-
-  writeFileSync(join(distDir, "index.html"), "<!DOCTYPE html>" + html);
-  console.log("✓ index.html готов");
 }
 
 build().catch(err => {

--- a/src/client/index.tsx
+++ b/src/client/index.tsx
@@ -2,8 +2,4 @@ import React from "react";
 import { hydrateRoot } from "react-dom/client";
 import App from "../app/App";
 
-// JSON-данные, которые build.ts вшивает в страницу
-const payloadElement = document.getElementById("__DATA__");
-const payload = payloadElement ? JSON.parse(payloadElement.textContent!) : {};
-
-hydrateRoot(document.getElementById("__APP__")!, <App {...payload} />);
+hydrateRoot(document.getElementById("root")!, <App />);

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -17,10 +17,10 @@ export default function Layout({ title, children }: Props) {
       <body>
         <header>
           <nav>
-            <a href="/">Home</a> | <a href="/about.html">About</a>
+            <a href="/">Home</a> | <a href="/about.html">About</a> | <a href="/contact.html">Contact</a>
           </nav>
         </header>
-        <main>{children}</main>
+        <main id="root">{children}</main>
         <footer>
           <p>© MySSG 2025</p>
         </footer>

--- a/src/pages/contact.tsx
+++ b/src/pages/contact.tsx
@@ -1,0 +1,11 @@
+import React from "react";
+import Layout from "../components/Layout";
+
+export default function ContactPage() {
+  return (
+    <Layout title="Контакты">
+      <h1>Связаться с нами</h1>
+      <p>Вы можете связаться по email: contact@example.com</p>
+    </Layout>
+  );
+}


### PR DESCRIPTION
## Summary
- enable routing with react-router
- build each page under `src/pages` into `/dist`
- hydrate the app via `root` element
- add contact page
- link new pages in navigation

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6840a3c99d8c832481604b6df4408776