### PR TITLE
Enable client-side navigation

### DIFF
--- a/src/app/routes.tsx
+++ b/src/app/routes.tsx
@@ -3,13 +3,16 @@ import { Routes, Route } from "react-router-dom";
 import HomePage from "../pages/index";
 import AboutPage from "../pages/about";
 import ContactPage from "../pages/contact";
+import Layout from "../components/Layout";
 
 export default function AppRoutes() {
   return (
     <Routes>
-      <Route path="/" element={<HomePage />} />
-      <Route path="/about.html" element={<AboutPage />} />
-      <Route path="/contact.html" element={<ContactPage />} />
+      <Route element={<Layout />}>
+        <Route path="/" element={<HomePage />} />
+        <Route path="/about.html" element={<AboutPage />} />
+        <Route path="/contact.html" element={<ContactPage />} />
+      </Route>
     </Routes>
   );
 }

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import { Link } from "react-router-dom";
 
 type Props = {
   title: string;
@@ -17,7 +18,7 @@ export default function Layout({ title, children }: Props) {
       <body>
         <header>
           <nav>
-            <a href="/">Home</a> | <a href="/about.html">About</a> | <a href="/contact.html">Contact</a>
+            <Link to="/">Home</Link> | <Link to="/about.html">About</Link> | <Link to="/contact.html">Contact</Link>
           </nav>
         </header>
         <main id="root">{children}</main>

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -1,12 +1,15 @@
 import React from "react";
-import { Link } from "react-router-dom";
+import { Link, Outlet, useLocation } from "react-router-dom";
 
-type Props = {
-  title: string;
-  children: React.ReactNode;
+const titles: Record<string, string> = {
+  "/": "Главная",
+  "/about.html": "О нас",
+  "/contact.html": "Контакты",
 };
 
-export default function Layout({ title, children }: Props) {
+export default function Layout() {
+  const location = useLocation();
+  const title = titles[location.pathname] ?? "MySSG";
   return (
     <html>
       <head>
@@ -21,7 +24,9 @@ export default function Layout({ title, children }: Props) {
             <Link to="/">Home</Link> | <Link to="/about.html">About</Link> | <Link to="/contact.html">Contact</Link>
           </nav>
         </header>
-        <main id="root">{children}</main>
+        <main id="root">
+          <Outlet />
+        </main>
         <footer>
           <p>© MySSG 2025</p>
         </footer>

--- a/src/pages/about.tsx
+++ b/src/pages/about.tsx
@@ -1,14 +1,13 @@
 import React from "react";
-import Layout from "../components/Layout";
 
 export default function AboutPage() {
   return (
-    <Layout title="О нас">
+    <>
       <h1>О проекте MySSG</h1>
       <p>
         MySSG — простой пример статической генерации React-приложения. Здесь
         каждая страница собирается в HTML во время сборки.
       </p>
-    </Layout>
+    </>
   );
 }

--- a/src/pages/contact.tsx
+++ b/src/pages/contact.tsx
@@ -1,11 +1,10 @@
 import React from "react";
-import Layout from "../components/Layout";
 
 export default function ContactPage() {
   return (
-    <Layout title="Контакты">
+    <>
       <h1>Связаться с нами</h1>
       <p>Вы можете связаться по email: contact@example.com</p>
-    </Layout>
+    </>
   );
 }

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,12 +1,11 @@
 import React from "react";
-import Layout from "../components/Layout";
 import CounterIsland from "../components/CounterIsland";
 
 export default function HomePage() {
   return (
-    <Layout title="Главная">
+    <>
       <h1>Статическая + интерактивная страница</h1>
       <CounterIsland />
-    </Layout>
+    </>
   );
 }


### PR DESCRIPTION
## Summary
- use `Link` from `react-router-dom` in the layout navigation

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6840acdf0bbc8324a5c2fdd14aa294c4