### PR TITLE
Add dynamic todo & theme pages

### DIFF
--- a/public/assets/styles.css
+++ b/public/assets/styles.css
@@ -26,3 +26,8 @@ footer {
   padding: 1rem;
   text-align: center;
 }
+
+body[data-theme="dark"] {
+  background: #222;
+  color: #fff;
+}

--- a/src/app/routes.tsx
+++ b/src/app/routes.tsx
@@ -3,6 +3,8 @@ import { Routes, Route } from "react-router-dom";
 import HomePage from "../pages/index";
 import AboutPage from "../pages/about";
 import ContactPage from "../pages/contact";
+import TodoPage from "../pages/todo";
+import ThemePage from "../pages/theme";
 
 export default function AppRoutes() {
   return (
@@ -10,6 +12,8 @@ export default function AppRoutes() {
       <Route path="/" element={<HomePage />} />
       <Route path="/about.html" element={<AboutPage />} />
       <Route path="/contact.html" element={<ContactPage />} />
+      <Route path="/todo.html" element={<TodoPage />} />
+      <Route path="/theme.html" element={<ThemePage />} />
     </Routes>
   );
 }

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -17,7 +17,11 @@ export default function Layout({ title, children }: Props) {
       <body>
         <header>
           <nav>
-            <a href="/">Home</a> | <a href="/about.html">About</a> | <a href="/contact.html">Contact</a>
+            <a href="/">Home</a> |
+            <a href="/about.html">About</a> |
+            <a href="/contact.html">Contact</a> |
+            <a href="/todo.html">Todo</a> |
+            <a href="/theme.html">Theme</a>
           </nav>
         </header>
         <main id="root">{children}</main>

--- a/src/components/ThemeToggleIsland.tsx
+++ b/src/components/ThemeToggleIsland.tsx
@@ -1,0 +1,16 @@
+'use client';
+import { useEffect, useState } from "react";
+
+export default function ThemeToggleIsland() {
+  const [dark, setDark] = useState(false);
+
+  useEffect(() => {
+    document.body.dataset.theme = dark ? "dark" : "light";
+  }, [dark]);
+
+  return (
+    <button data-island="theme-toggle" onClick={() => setDark(d => !d)}>
+      {dark ? "Светлая тема" : "Тёмная тема"}
+    </button>
+  );
+}

--- a/src/components/TodoIsland.tsx
+++ b/src/components/TodoIsland.tsx
@@ -1,0 +1,37 @@
+'use client';
+import { useState } from "react";
+
+export default function TodoIsland() {
+  const [items, setItems] = useState<string[]>([]);
+  const [input, setInput] = useState("");
+
+  const addItem = () => {
+    const value = input.trim();
+    if (value) {
+      setItems([...items, value]);
+      setInput("");
+    }
+  };
+
+  const removeItem = (index: number) => {
+    setItems(items.filter((_, i) => i !== index));
+  };
+
+  return (
+    <div data-island="todo">
+      <input
+        value={input}
+        onChange={(e) => setInput(e.target.value)}
+        placeholder="Новая задача"
+      />
+      <button onClick={addItem}>Добавить</button>
+      <ul>
+        {items.map((item, i) => (
+          <li key={i}>
+            {item} <button onClick={() => removeItem(i)}>×</button>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/src/pages/theme.tsx
+++ b/src/pages/theme.tsx
@@ -1,0 +1,12 @@
+import React from "react";
+import Layout from "../components/Layout";
+import ThemeToggleIsland from "../components/ThemeToggleIsland";
+
+export default function ThemePage() {
+  return (
+    <Layout title="Темы">
+      <h1>Переключение темы</h1>
+      <ThemeToggleIsland />
+    </Layout>
+  );
+}

--- a/src/pages/todo.tsx
+++ b/src/pages/todo.tsx
@@ -1,0 +1,12 @@
+import React from "react";
+import Layout from "../components/Layout";
+import TodoIsland from "../components/TodoIsland";
+
+export default function TodoPage() {
+  return (
+    <Layout title="Задачи">
+      <h1>Мой список задач</h1>
+      <TodoIsland />
+    </Layout>
+  );
+}


### PR DESCRIPTION
## Summary
- add new interactive TodoIsland and ThemeToggleIsland
- create Todo and Theme pages that use the islands
- update nav and routes for the new pages
- support dark theme in CSS

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6840ad05ce5883249d71163c2fe5aeeb