### PR TITLE
Add getStaticProps support

### DIFF
--- a/src/app/routes.tsx
+++ b/src/app/routes.tsx
@@ -1,21 +1,23 @@
-import { Routes, Route } from "react-router-dom"
-import HomePage from "../pages/index"
-import AboutPage from "../pages/about"
-import ContactPage from "../pages/contact"
-import Layout from "../components/Layout"
-import TodoPage from "../pages/todo"
-import ThemePage from "../pages/theme"
+import { Routes, Route } from "react-router-dom";
+import HomePage from "../pages/index";
+import AboutPage from "../pages/about";
+import ContactPage from "../pages/contact";
+import Layout from "../components/Layout";
+import TodoPage from "../pages/todo";
+import ThemePage from "../pages/theme";
 
-export default function AppRoutes() {
+export type PagePropsMap = Record<string, any>;
+
+export default function AppRoutes({ pageProps = {} }: { pageProps?: PagePropsMap } = {}) {
   return (
     <Routes>
       <Route element={<Layout />}>
-        <Route path="/" element={<HomePage />} />
-        <Route path="/about.html" element={<AboutPage />} />
-        <Route path="/contact.html" element={<ContactPage />} />
-        <Route path="/todo.html" element={<TodoPage />} />
-        <Route path="/theme.html" element={<ThemePage />} />
+        <Route path="/" element={<HomePage {...pageProps["/"]} />} />
+        <Route path="/about.html" element={<AboutPage {...pageProps["/about.html"]} />} />
+        <Route path="/contact.html" element={<ContactPage {...pageProps["/contact.html"]} />} />
+        <Route path="/todo.html" element={<TodoPage {...pageProps["/todo.html"]} />} />
+        <Route path="/theme.html" element={<ThemePage {...pageProps["/theme.html"]} />} />
       </Route>
     </Routes>
-  )
+  );
 }

--- a/src/pages/about.tsx
+++ b/src/pages/about.tsx
@@ -1,6 +1,16 @@
 import React from "react";
 
-export default function AboutPage() {
+export async function getStaticProps() {
+  try {
+    const res = await fetch("https://api.chucknorris.io/jokes/random");
+    const data = await res.json();
+    return { props: { joke: data.value } };
+  } catch {
+    return { props: { joke: "Не удалось получить шутку" } };
+  }
+}
+
+export default function AboutPage({ joke }: { joke?: string }) {
   return (
     <>
       <h1>О проекте MySSG</h1>
@@ -8,6 +18,11 @@ export default function AboutPage() {
         MySSG — простой пример статической генерации React-приложения. Здесь
         каждая страница собирается в HTML во время сборки.
       </p>
+      {joke && (
+        <blockquote>
+          <p>{joke}</p>
+        </blockquote>
+      )}
     </>
   );
 }


### PR DESCRIPTION
## Summary
- support passing static props to pages
- fetch a joke during build for About page

## Testing
- `npm run build` *(fails: Cannot find package 'ts-node')*

------
https://chatgpt.com/codex/tasks/task_e_68413ade19a08324bbac8fa69318edc3